### PR TITLE
pflag: ignore invalid flags

### DIFF
--- a/Godeps/_workspace/src/github.com/spf13/pflag/flag.go
+++ b/Godeps/_workspace/src/github.com/spf13/pflag/flag.go
@@ -106,6 +106,8 @@ import (
 	"os"
 	"sort"
 	"strings"
+
+	log "github.com/Sirupsen/logrus"
 )
 
 // ErrHelp is the error returned if the flag -help is invoked but no such flag is defined.
@@ -743,7 +745,10 @@ func (f *FlagSet) parseLongArg(s string, args []string) (a []string, err error) 
 			f.usage()
 			return a, ErrHelp
 		}
-		err = f.failf("unknown flag: --%s", name)
+		// Don't set an error here, just output a warning.
+		log.WithFields(log.Fields{
+			"flag": name,
+		}).Warn("ignoring unknown long flag")
 		return
 	}
 	var value string
@@ -778,8 +783,11 @@ func (f *FlagSet) parseSingleShortArg(shorthands string, args []string) (outShor
 			err = ErrHelp
 			return
 		}
-		//TODO continue on error
-		err = f.failf("unknown shorthand flag: %q in -%s", c, shorthands)
+		// Don't set an error here, just output a warning.
+		log.WithFields(log.Fields{
+			"flag": string(c),
+			"argv": shorthands,
+		}).Warn("ignoring unknown shorthand flag")
 		return
 	}
 	var value string


### PR DESCRIPTION
In order to ensure that it is possible to use /etc/sysconfig/docker, we
have to ignore any undefined flags. Since the migrator doesn't require
any positional arguments, this means we can ignore all undefined
and left-over arguments.

We print warnings so the user is somewhat aware of what's going on.

Signed-off-by: Aleksa Sarai asarai@suse.de
## 

I know it's bad form to modify a vendored package, but I feel like this is a special case (upstream wouldn't accept it, but having this code means that people can just append their normal Docker command-line flags to the migrator).

/cc @tonistiigi 
